### PR TITLE
Adapt metrics to Siren federate 26

### DIFF
--- a/collectors/cluster_health.go
+++ b/collectors/cluster_health.go
@@ -180,7 +180,7 @@ func (c ClusterHealthCollector) Collect(metrics chan<- prometheus.Metric) {
 		}
 		value, err := m.transform(jresult)
 		if err != nil {
-			log.Println(fmt.Sprintf("transform failed for %s: %s", m.path, err.Error()))
+			log.Printf("transform failed for %s: %s\n", m.path, err.Error())
 		}
 		metrics <- prometheus.MustNewConstMetric(m.descriptor, prometheus.GaugeValue, value)
 	}


### PR DESCRIPTION
From Siren Federate [26 release notes](https://docs.siren.io/siren-federate-user-guide/26/siren-federate/release-notes.html):
> Changed the format of the JSON response for [Cluster APIs Nodes Statistics](https://docs.siren.io/siren-federate-user-guide/26/siren-federate/cluster-apis.html#_nodes_statistics)